### PR TITLE
Specify package list for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,19 @@ description = "Legal navigator for Victorian renters"
 requires-python = ">=3.11"
 dependencies = []
 
+[tool.setuptools]
+packages = [
+    "agents",
+    "api",
+    "core",
+    "knowledge",
+    "llm",
+    "scheduler",
+    "rag_indexer",
+    "fastapi",
+    "pydantic",
+]
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.2,<9.0",


### PR DESCRIPTION
## Summary
- configure setuptools with an explicit list of packages so editable installs succeed without relying on auto-discovery

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4b636b608331b24b85aeb2c82972